### PR TITLE
fix(sas): fix not detecting the container name from the sas url

### DIFF
--- a/.github/workflows/check_pr_title_style.yml
+++ b/.github/workflows/check_pr_title_style.yml
@@ -44,7 +44,7 @@ jobs:
           # subject. The `headerPattern` should contain a regex where the capturing groups in parentheses
           # correspond to the parts listed in `headerPatternCorrespondence`.
           # See: https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#headerpattern
-          headerPattern: '^(\w*)(?:\(([\w$.\-*/ ]*)\))?: (.*)$'
+          headerPattern: '^(\w*)(?:\(([\w$.,\-,*/ ]*)\))?: (.*)$'
           headerPatternCorrespondence: type, scope, subject
           # For work-in-progress PRs you can typically use draft pull requests
           # from GitHub. However, private repositories on the free plan don't have

--- a/__tests__/blob.test.ts
+++ b/__tests__/blob.test.ts
@@ -31,7 +31,6 @@ describe("BlobStorage", () => {
     expect(result).toBe(false)
   })
 
-
   it("should generate a SAS URL and be able to create a file with it", async () => {
     const blob = new BlobStorage(storageConnectionString)
     blob.createContainer("testcontainer")

--- a/__tests__/blob.test.ts
+++ b/__tests__/blob.test.ts
@@ -22,15 +22,6 @@ describe("BlobStorage", () => {
     expect(result).toEqual([])
   })
 
-  //   it("should download a blob", async () => {
-  //     const blob = new BlobStorage(storageConnectionString)
-  //     await blob.createContainer("testcontainer")
-
-  //     const result = await blob.downloadBlob("testcontainer", "testblob")
-
-  //     expect(result).toBeInstanceOf(Buffer)
-  //   })
-
   it("should check if a blob exists", async () => {
     const blob = new BlobStorage(storageConnectionString)
     blob.createContainer("testcontainer")

--- a/__tests__/blob.test.ts
+++ b/__tests__/blob.test.ts
@@ -43,7 +43,7 @@ describe("BlobStorage", () => {
       permissions: [BlobPermissions.WRITE],
     }
     const sasUrl = blob.generateSASUrl(containerName, blobPath, sasOptions)
-    expect(sasUrl.split("?")?.[0]).toEqual("http://127.0.0.1:10000/devstoreaccount1")
+    expect(sasUrl.split("?")?.[0]).toEqual(`http://127.0.0.1:10000/devstoreaccount1/${containerName}`)
   })
 
   it("should upload data using SAS URL", async () => {
@@ -54,7 +54,9 @@ describe("BlobStorage", () => {
     }
     const sasUrl = blob.generateSASUrl(containerName, blobPath, sasOptions)
 
-    await blob.uploadData(containerName, blobPath, Buffer.from("test data"), sasUrl)
+    const newBlob = new BlobStorage(sasUrl)
+
+    await newBlob.uploadData("", blobPath, Buffer.from("test data"), sasUrl)
 
     const blobExists = await blob.blobExists(containerName, blobPath)
     expect(blobExists).toBe(true)

--- a/__tests__/blob.test.ts
+++ b/__tests__/blob.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, jest } from "@jest/globals"
+
+import { BlobStorage, BlobPermissions, SASOptions } from "../src/blob"
+import exp from "constants"
+
+const storageConnectionString =
+  "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;QueueEndpoint=http://127.0.0.1:10001/devstoreaccount1;TableEndpoint=http://127.0.0.1:10002/devstoreaccount1;"
+
+describe("BlobStorage", () => {
+  it("should get a BlobServiceClient object", () => {
+    const blob = new BlobStorage(storageConnectionString)
+    const blobServiceClient = blob.getBlobServiceUrl()
+
+    expect(blobServiceClient).toBeDefined()
+  })
+
+  it("should list blobs", async () => {
+    const blob = new BlobStorage(storageConnectionString)
+    await blob.createContainer("testcontainer")
+    const result = await blob.listBlobs("testcontainer", "testblob")
+
+    expect(result).toEqual([])
+  })
+
+  //   it("should download a blob", async () => {
+  //     const blob = new BlobStorage(storageConnectionString)
+  //     await blob.createContainer("testcontainer")
+
+  //     const result = await blob.downloadBlob("testcontainer", "testblob")
+
+  //     expect(result).toBeInstanceOf(Buffer)
+  //   })
+
+  it("should check if a blob exists", async () => {
+    const blob = new BlobStorage(storageConnectionString)
+    blob.createContainer("testcontainer")
+
+    const result = await blob.blobExists("testcontainer", "testblob")
+
+    expect(result).toBe(false)
+  })
+
+
+  it("should generate a SAS URL and be able to create a file with it", async () => {
+    const blob = new BlobStorage(storageConnectionString)
+    blob.createContainer("testcontainer")
+
+    const sasOptions: SASOptions = {
+      startsOn: new Date(),
+      expires: 3600,
+      permissions: [BlobPermissions.WRITE],
+    }
+    const sasUrl = blob.generateSASUrl("testcontainer", "path/testblob.txt", sasOptions)
+
+    expect(sasUrl.split("?")?.[0]).toEqual("http://127.0.0.1:10000/devstoreaccount1")
+
+    blob.uploadData("testcontainer", "path/testblob.txt", Buffer.from("test data"), sasUrl)
+
+    const blobExists = await blob.blobExists("testcontainer", "path/testblob.txt")
+
+    expect(blobExists).toBe(true)
+  })
+})

--- a/__tests__/blob.test.ts
+++ b/__tests__/blob.test.ts
@@ -36,27 +36,27 @@ describe("BlobStorage", () => {
     expect(result).toBe(false)
   })
 
-  it("should generate a valid SAS URL", async () => {  
-    const sasOptions: SASOptions = {  
-      startsOn: new Date(),  
-      expires: 3600,  
-      permissions: [BlobPermissions.WRITE],  
-    };  
-    const sasUrl = blob.generateSASUrl(containerName, blobPath, sasOptions);  
-    expect(sasUrl.split("?")?.[0]).toEqual("http://127.0.0.1:10000/devstoreaccount1");  
-  });  
+  it("should generate a valid SAS URL", async () => {
+    const sasOptions: SASOptions = {
+      startsOn: new Date(),
+      expires: 3600,
+      permissions: [BlobPermissions.WRITE],
+    }
+    const sasUrl = blob.generateSASUrl(containerName, blobPath, sasOptions)
+    expect(sasUrl.split("?")?.[0]).toEqual("http://127.0.0.1:10000/devstoreaccount1")
+  })
 
-  it("should upload data using SAS URL", async () => {  
-    const sasOptions: SASOptions = {  
-      startsOn: new Date(),  
-      expires: 3600,  
-      permissions: [BlobPermissions.WRITE],  
-    };  
-    const sasUrl = blob.generateSASUrl(containerName, blobPath, sasOptions);  
-    
-    await blob.uploadData(containerName, blobPath, Buffer.from("test data"), sasUrl);  
+  it("should upload data using SAS URL", async () => {
+    const sasOptions: SASOptions = {
+      startsOn: new Date(),
+      expires: 3600,
+      permissions: [BlobPermissions.WRITE],
+    }
+    const sasUrl = blob.generateSASUrl(containerName, blobPath, sasOptions)
 
-    const blobExists = await blob.blobExists(containerName, blobPath);  
-    expect(blobExists).toBe(true);  
-  });
+    await blob.uploadData(containerName, blobPath, Buffer.from("test data"), sasUrl)
+
+    const blobExists = await blob.blobExists(containerName, blobPath)
+    expect(blobExists).toBe(true)
+  })
 })

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -222,6 +222,6 @@ export class BlobStorage {
     const sharedKeyCredential = new StorageSharedKeyCredential(accountName, accountKey)
     const sasToken = generateBlobSASQueryParameters(options, sharedKeyCredential).toString()
 
-    return `${blobService.url}?${sasToken}`
+    return `${container.url}?${sasToken}`
   }
 }

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -8,14 +8,10 @@ import {
   HttpRequestBody,
   StorageSharedKeyCredential,
 } from "@azure/storage-blob"
-import { AzureLogger, setLogLevel } from "@azure/logger"
+import { setLogLevel } from "@azure/logger"
 import { Readable } from "stream"
 
-setLogLevel("verbose")
-
-AzureLogger.log = (...args) => {
-  console.log(...args)
-}
+setLogLevel("error")
 
 export enum BlobPermissions {
   READ = "r",


### PR DESCRIPTION
### Short Summary

- Update the generate sas url to send the container name with the sas url
- Update the tests for blob generating a sas url

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the expected SAS URL format in tests to include the container name.
	- Adjusted the instantiation of the `BlobStorage` object to use the generated SAS URL directly for uploads.
- **Improvements**
	- Modified the SAS URL generation to reference the specific container URL, enhancing accuracy in data operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->