### PR TITLE
fix(blob): update generateSASUrl method to take expiresOn as a Date

### DIFF
--- a/__tests__/blob.test.ts
+++ b/__tests__/blob.test.ts
@@ -39,7 +39,7 @@ describe("BlobStorage", () => {
   it("should generate a valid SAS URL", async () => {
     const sasOptions: SASOptions = {
       startsOn: new Date(),
-      expires: 3600,
+      expiresOn: new Date(new Date().valueOf() + 3600 * 1000),
       permissions: [BlobPermissions.WRITE],
     }
     const sasUrl = blob.generateSASUrl(containerName, blobPath, sasOptions)
@@ -49,7 +49,7 @@ describe("BlobStorage", () => {
   it("should upload data using SAS URL", async () => {
     const sasOptions: SASOptions = {
       startsOn: new Date(),
-      expires: 3600,
+      expiresOn: new Date(new Date().valueOf() + 3600 * 1000),
       permissions: [BlobPermissions.WRITE],
     }
     const sasUrl = blob.generateSASUrl(containerName, blobPath, sasOptions)
@@ -65,7 +65,7 @@ describe("BlobStorage", () => {
   it("should upload data using SAS URL and set the content type", async () => {
     const sasOptions: SASOptions = {
       startsOn: new Date(),
-      expires: 3600,
+      expiresOn: new Date(new Date().valueOf() + 3600 * 1000),
       permissions: [BlobPermissions.WRITE],
     }
     const sasUrl = blob.generateSASUrl(containerName, blobPath, sasOptions)

--- a/src/blob.ts
+++ b/src/blob.ts
@@ -24,7 +24,7 @@ export enum BlobPermissions {
 
 export interface SASOptions {
   startsOn?: Date
-  expires?: number
+  expiresOn?: Date
   permissions?: BlobPermissions[]
 }
 
@@ -216,13 +216,17 @@ export class BlobStorage {
     const blobService = this.getBlobServiceUrl()
     const container = blobService.getContainerClient(containerName)
 
-    const { startsOn = new Date(), expires = 3600, permissions = [BlobPermissions.READ] } = sasOptions
+    const {
+      startsOn = new Date(),
+      expiresOn = new Date(new Date().valueOf() + 3600 * 1000),
+      permissions = [BlobPermissions.READ],
+    } = sasOptions
 
     const options = {
       containerName,
       blobName,
       startsOn,
-      expiresOn: new Date(Date.now() + expires * 1000),
+      expiresOn,
       permissions: BlobSASPermissions.parse(permissions.join("")),
     }
 


### PR DESCRIPTION
BREAKING CHANGE: Sas option `expires: number` was replaced by `expiresOn: Date`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated SAS (Shared Access Signature) token generation to use explicit date-based expiration
	- Improved handling of token expiration times with more precise `Date` object support

- **Bug Fixes**
	- Refined SAS URL generation to provide clearer expiration time management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->