### PR TITLE
docs(readme): replace h4 headings with bold text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,12 @@ Do not manually bump versions in `package.json`.
 - Keep TypeScript at `^5.x` — **do not upgrade to TypeScript 6.x** until `ts-jest` adds support
 - Build with `npm run build` (compiles to `dist/`)
 
+## README / Documentation
+
+- **Maximum heading depth is h3 (`###`)** — never use `####` or deeper in README.md
+- The README is mirrored as MDX on akadenia.com, which only supports h1–h3. h4+ headings break the MDX parser and the website build.
+- Use **bold text** instead of h4 for sub-sections under h3.
+
 ## Testing
 
 - Tests live in `__tests__/`, run with `jest`

--- a/README.MD
+++ b/README.MD
@@ -180,7 +180,7 @@ const containerSas = await blobStorage.generateSASUrl('my-container', undefined,
 });
 ```
 
-#### SAS Permissions
+**SAS Permissions**
 
 ```typescript
 import { BlobPermissions } from '@akadenia/azure-storage';
@@ -380,7 +380,7 @@ const queueStorage = new QueueStorage("UseDevelopmentStorage=true");
 
 ### Managed Identity Authentication
 
-#### System-Assigned (Most Common)
+**System-Assigned (Most Common)**
 
 Automatically created when you enable managed identity on your Azure resource — no client ID needed.
 
@@ -390,7 +390,7 @@ const tableStorage = new TableStorage({ accountName: 'yourstorageaccount', table
 const queueStorage = new QueueStorage({ accountName: 'yourstorageaccount' });
 ```
 
-#### User-Assigned
+**User-Assigned**
 
 A standalone identity shared across multiple Azure resources. Requires the client ID.
 
@@ -401,7 +401,7 @@ const blobStorage = new BlobStorage({
 });
 ```
 
-#### Environment-Based Configuration
+**Environment-Based Configuration**
 
 ```typescript
 const blobStorage = process.env.NODE_ENV === 'production'


### PR DESCRIPTION
## Problem
Changes to the README introduced h4 headings which broke MDX parsing in the website assets repo.

## Fix
- Converted all 4 h4 headings to bold text
- Added AGENTS.md rule: max heading depth is h3

## Changed Files
- README.MD: 4x h4 → bold
- AGENTS.md: new heading depth rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README formatting for improved consistency and platform compatibility
  * Established documentation standards to maintain consistent structure and readability across all resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->