### PR TITLE
fix(ci): add tagFormat to .releaserc.json to align with manual release tags

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": ["main"],
+  "tagFormat": "${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Adds `tagFormat: "\"` so semantic-release recognizes existing manual release tags (e.g. `2.6.1`) instead of defaulting to `v` prefix and colliding with npm published versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release tagging so new versions use the version number directly.
  * Release tags will now follow a simpler, consistent format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->