### PR TITLE
fix: consolidate release PR creation into commit-release-assets.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,38 +44,6 @@ jobs:
       - run:
           name: Semantic Release
           command: npx semantic-release
-      - run:
-          name: Create Release Assets PR
-          command: |
-            VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-            if [ -n "$VERSION" ] && git log -1 --format=%s | grep -q "chore(release)"; then
-              PAYLOAD=$(jq -n \
-                --arg title "chore(release): merge release ${VERSION} assets" \
-                --arg head "release/${VERSION}" \
-                --arg base "main" \
-                --arg body "Merge release ${VERSION} assets" \
-                '{title: $title, head: $head, base: $base, body: $body}')
-              RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
-                -H "Authorization: Bearer ${GH_TOKEN}" \
-                -H "Accept: application/vnd.github+json" \
-                "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls" \
-                -d "$PAYLOAD")
-              HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-              BODY=$(echo "$RESPONSE" | head -n -1)
-              if [ "$HTTP_CODE" = "201" ]; then
-                echo "Release PR created successfully."
-              elif [ "$HTTP_CODE" = "422" ]; then
-                if echo "$BODY" | grep -qi "pull request already exists"; then
-                  echo "Release PR already exists — skipping."
-                else
-                  echo "PR creation failed with unexpected 422: $BODY"
-                  exit 1
-                fi
-              else
-                echo "PR creation failed (HTTP $HTTP_CODE): $BODY"
-                exit 1
-              fi
-            fi
 
 workflows:
   ci:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,13 +18,6 @@
         "npmPublish": true
       }
     ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "pnpm-lock.yaml", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
     "@semantic-release/github"
   ]
 }

--- a/scripts/commit-release-assets.sh
+++ b/scripts/commit-release-assets.sh
@@ -32,3 +32,28 @@ git commit -m "chore(release): add release assets from $VERSION"
 git remote set-url origin "https://${GH_TOKEN}@github.com/akadenia/AkadeniaAzureStorage.git"
 git push origin $BRANCH_NAME
 
+# Open PR
+PAYLOAD=$(jq -n \
+  --arg title "chore(release): merge release ${VERSION} assets" \
+  --arg head "$BRANCH_NAME" \
+  --arg base "main" \
+  --arg body "Merge release ${VERSION} assets" \
+  '{title: $title, head: $head, base: $base, body: $body}')
+
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
+  -H "Authorization: Bearer ${GH_TOKEN}" \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls" \
+  -d "$PAYLOAD")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | head -n -1)
+
+if [ "$HTTP_CODE" = "201" ]; then
+  echo "Release PR created successfully."
+elif [ "$HTTP_CODE" = "422" ] && echo "$BODY" | grep -qi "pull request already exists"; then
+  echo "Release PR already exists — skipping."
+else
+  echo "PR creation failed (HTTP $HTTP_CODE): $BODY"
+  exit 1
+fi


### PR DESCRIPTION
- Remove @semantic-release/git plugin from .releaserc.json to prevent double-committing release assets to main
- Add PR creation logic to scripts/commit-release-assets.sh using CIRCLE_PROJECT_USERNAME and CIRCLE_PROJECT_REPONAME
- Remove redundant 'Create Release Assets PR' step from .circleci/config.yml